### PR TITLE
added prepublish to esdoc2-publish-html-plugin

### DIFF
--- a/packages/esdoc2-publish-html-plugin/package.json
+++ b/packages/esdoc2-publish-html-plugin/package.json
@@ -39,6 +39,7 @@
     "node": ">= 6.0.0"
   },
   "scripts": {
+    "prepublish": "npm run build",
     "build": "rm -rf ./out/src && babel --out-dir out/src --ignore 'Builder/template' src && cp -a src/Builder/template out/src/Builder/",
     "test": "rm -rf ./test/fixture/out && node ./test/init.js && mocha -t 10000 --require ./node_modules/babel-register --recursive ./test/src -R spec"
   },


### PR DESCRIPTION
This just adds a prepublish build to the esdoc2-publish-html-plugin.

Fixes: 
https://github.com/esdoc2/esdoc2/issues/6
https://github.com/esdoc2/esdoc2-plugins/issues/10

It seemed to build fine for me locally so I'd be happy to publish it to npm if you want to add me as a contributor. https://www.npmjs.com/~shannonmpoole.