### PR TITLE
Change build chain to properly use lerna

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "2.1.0"
+  "version": "2.1.0",
+  "useWorkspaces": true
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "test": "lerna run test",
     "publish": "lerna publish",
-    "preinstall": "lerna bootstrap --npm-client=yarn"
+    "bootstrap": "lerna bootstrap --npm-client=npm"
   },
   "description": "esdoc2 plugin mono repo",
   "main": "index.js",


### PR DESCRIPTION
In the current setup lerna cannot be installed using ```npm install``` because preinstall is using it. Additionally lerna.json was missing the ```"useWorkspaces": true``` option.