### PR TITLE
Add .npmignore to esdoc2-publish-html-plugin

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,6 +3,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "2.1.0",
+  "version": "2.1.1",
   "useWorkspaces": true
 }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "dependencies": {
     "esdoc2": "latest",
-    "lerna": "^2.5.1",    
+    "lerna": "^2.5.1",
     "esdoc2-accessor-plugin": "*",
     "esdoc2-brand-plugin": "*",
     "esdoc2-coverage-plugin": "*",

--- a/packages/esdoc2-ecmascript-proposal-plugin/package.json
+++ b/packages/esdoc2-ecmascript-proposal-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esdoc2-ecmascript-proposal-plugin",
-  "version": "2.0.0",
+  "version": "2.1.1",
   "description": "A ECMAScript proposal plugin for esdoc2",
   "author": "h13i32maru",
   "homepage": "https://github.com/esdoc2/esdoc2-plugins",

--- a/packages/esdoc2-publish-html-plugin/.npmignore
+++ b/packages/esdoc2-publish-html-plugin/.npmignore
@@ -1,0 +1,3 @@
+src
+test
+node_modules

--- a/packages/esdoc2-publish-html-plugin/package.json
+++ b/packages/esdoc2-publish-html-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esdoc2-publish-html-plugin",
-  "version": "2.0.2",
+  "version": "2.1.1",
   "description": "A publish HTML plugin for esdoc2",
   "author": "h13i32maru",
   "homepage": "https://github.com/esdoc2/esdoc2-plugins",

--- a/packages/esdoc2-publish-markdown-plugin/package.json
+++ b/packages/esdoc2-publish-markdown-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esdoc2-publish-markdown-plugin",
-  "version": "2.0.0",
+  "version": "2.1.1",
   "description": "A publish markdown plugin for esdoc2 [PoC]",
   "author": "h13i32maru",
   "homepage": "https://github.com/esdoc2/esdoc2-plugins",

--- a/packages/esdoc2-standard-plugin/package.json
+++ b/packages/esdoc2-standard-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esdoc2-standard-plugin",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A standard plugin for esdoc2",
   "author": "h13i32maru",
   "homepage": "https://github.com/esdoc2/esdoc2-plugins",
@@ -17,7 +17,7 @@
     "esdoc2-integrate-manual-plugin": "^2.1.0",
     "esdoc2-integrate-test-plugin": "^2.0.0",
     "esdoc2-lint-plugin": "^2.0.0",
-    "esdoc2-publish-html-plugin": "^2.0.1",
+    "esdoc2-publish-html-plugin": "^2.1.1",
     "esdoc2-type-inference-plugin": "^2.0.1",
     "esdoc2-undocumented-identifier-plugin": "^2.0.0",
     "esdoc2-unexported-identifier-plugin": "^2.0.0"


### PR DESCRIPTION
This assures that the ```out/src``` folder for esdoc2-publish-html-plugin does not get removed when publishing. Right now this occurs because the toplevel ```.gitignore``` specifies ```out```. By adding a ```.npmignore``` to the plugin folder the toplevel ```.gitignore``` gets overruled.